### PR TITLE
Add bash scripts

### DIFF
--- a/build_desktop.sh
+++ b/build_desktop.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+OUT_DIR="build/desktop"
+
+mkdir -p $OUT_DIR
+
+odin build main_desktop -out:$OUT_DIR/game_desktop.bin
+cp -R ./assets/ ./$OUT_DIR/assets/

--- a/build_web.sh
+++ b/build_web.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+EMSCRIPTEN_SDK_DIR="$HOME/emsdk"
+OUT_DIR="build/web"
+
+mkdir -p $OUT_DIR
+
+export EMSDK_QUIET=1
+# shellcheck disable=SC1091
+[[ -f "$EMSCRIPTEN_SDK_DIR/emsdk_env.sh" ]] && . "$EMSCRIPTEN_SDK_DIR/emsdk_env.sh"
+
+if ! odin build main_web -target:freestanding_wasm32 -build-mode:obj -define:RAYLIB_WASM_LIB=env.o -define:RAYGUI_WASM_LIB=env.o -vet -strict-style -out:$OUT_DIR/game; then
+  exit 1
+fi
+
+ODIN_PATH=$(odin root)
+files="main_web/main_web.c $OUT_DIR/game.wasm.o $ODIN_PATH/vendor/raylib/wasm/libraylib.a $ODIN_PATH/vendor/raylib/wasm/libraygui.a"
+flags="-sUSE_GLFW=3 -sASYNCIFY -sASSERTIONS -DPLATFORM_WEB"
+custom="--shell-file main_web/index_template.html --preload-file assets"
+
+# shellcheck disable=SC2086
+# Add `-g` to `emcc` call to enable debug symbols (works in chrome).
+emcc -o $OUT_DIR/index.html $files $flags $custom && rm $OUT_DIR/game.wasm.o
+cp -R ./assets/ ./$OUT_DIR/assets/


### PR DESCRIPTION
Add bash scripts for running on macOS/Linux. These are as close to a straight port of the batch scripts as I could get. I only added a check for the `emsdk` environment file in case it doesn't exist (ex. I source this already in my `.zshrc` and it exists in a different directory).

## Tested on

```
❯ uname -a
Darwin me.local 23.6.0 Darwin Kernel Version 23.6.0: Fri Nov 15 15:13:15 PST 2024; root:xnu-10063.141.1.702.7~1/RELEASE_ARM64_T6000 arm64
```

```
❯ emcc -v
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.74 (1092ec30a3fb1d46b1782ff1b4db5094d3d06ae5)
clang version 20.0.0git (https:/github.com/llvm/llvm-project 322eb1a92e6d4266184060346616fa0dbe39e731)
Target: wasm32-unknown-emscripten
Thread model: posix
InstalledDir: /Users/duffn/code/emsdk/upstream/bin
```

```
❯ odin version
odin version dev-2025-01:fdd3b46c1
```