### PR TITLE
Add ASYNCIFY flag to build_web.sh

### DIFF
--- a/build_web.sh
+++ b/build_web.sh
@@ -27,7 +27,7 @@ files="$OUT_DIR/game.wasm.o ${ODIN_PATH}/vendor/raylib/wasm/libraylib.a ${ODIN_P
 
 # index_template.html contains the javascript code that calls the procedures in
 # source/main_web/main_web.odin
-flags="-sUSE_GLFW=3 -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sASSERTIONS --shell-file source/main_web/index_template.html --preload-file assets"
+flags="-sUSE_GLFW=3 -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sASSERTIONS --shell-file source/main_web/index_template.html --preload-file assets -s ASYNCIFY"
 
 # For debugging: Add `-g` to `emcc` (gives better error callstack in chrome)
 emcc -o $OUT_DIR/index.html $files $flags


### PR DESCRIPTION
fixes compilation error (game not running): "Uncaught Please compile your program with async support in order to use asynchronous operations like emscripten_sleep"

I don't know if windows/bat needs the same.

I'm on latest odin release [dev-2025-09](https://github.com/odin-lang/Odin/releases/tag/dev-2025-09)