### PR TITLE
Add HEAPF32 to Emscripten exported methods to fix raylib audio

### DIFF
--- a/build_web.sh
+++ b/build_web.sh
@@ -30,7 +30,7 @@ files="$OUT_DIR/game.wasm.o ${ODIN_PATH}/vendor/raylib/wasm/libraylib.a ${ODIN_P
 flags="-sUSE_GLFW=3 -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sASSERTIONS --shell-file source/main_web/index_template.html --preload-file assets"
 
 # For debugging: Add `-g` to `emcc` (gives better error callstack in chrome)
-emcc -o $OUT_DIR/index.html $files $flags
+emcc -sEXPORTED_RUNTIME_METHODS=HEAPF32 -o $OUT_DIR/index.html $files $flags
 
 rm $OUT_DIR/game.wasm.o
 


### PR DESCRIPTION
Hello Karl,

I had the following error when trying to play a sound with raylib audio on the web build:

```
Aborted('HEAPF32' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ)) index.js:697:6 Uncaught RuntimeError: Aborted('HEAPF32' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ))
    abort http://localhost:8000/index.js:715
    get http://localhost:8000/index.js:584
    onaudioprocess http://localhost:8000/index.js:9622
index.js:715:11
```

This small patch fixed the issue for me (Firefox on Ubuntu).

Thanks for this neat template, cheers!