### PR TITLE
Removed the assets path from the copy in build_desktop.sh

### DIFF
--- a/build_desktop.sh
+++ b/build_desktop.sh
@@ -3,5 +3,5 @@
 OUT_DIR="build/desktop"
 mkdir -p $OUT_DIR
 odin build source/main_desktop -vet -strict-style -out:$OUT_DIR/game_desktop.bin
-cp -R ./assets/ ./$OUT_DIR/assets/
+cp -R ./assets/ ./$OUT_DIR/
 echo "Desktop build created in ${OUT_DIR}"


### PR DESCRIPTION
Removed the assets path from the copy in build_desktop.sh. As written it results in assets/assets/ after the first build. Had an issue when I populated some assets into the folder and kept getting file not found errors. This seems to only happen with the bash script, I can't check the windows batch file so no idea there.