### PR TITLE
Added HEAPF32 to exports in windows and linux wasm build to allow wor…

### DIFF
--- a/build_web.bat
+++ b/build_web.bat
@@ -27,7 +27,7 @@ set files=%OUT_DIR%\game.wasm.o %ODIN_PATH%\vendor\raylib\wasm\libraylib.a %ODIN
 
 :: index_template.html contains the javascript code that calls the procedures in
 :: source/main_web/main_web.odin
-set flags=-sUSE_GLFW=3 -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sASSERTIONS --shell-file source\main_web\index_template.html --preload-file assets
+set flags=-sEXPORTED_RUNTIME_METHODS=['HEAPF32'] -sUSE_GLFW=3 -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sASSERTIONS --shell-file source\main_web\index_template.html --preload-file assets
 
 :: For debugging: Add `-g` to `emcc` (gives better error callstack in chrome)
 ::

--- a/build_web.sh
+++ b/build_web.sh
@@ -27,7 +27,7 @@ files="$OUT_DIR/game.wasm.o ${ODIN_PATH}/vendor/raylib/wasm/libraylib.a ${ODIN_P
 
 # index_template.html contains the javascript code that calls the procedures in
 # source/main_web/main_web.odin
-flags="-sUSE_GLFW=3 -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sASSERTIONS --shell-file source/main_web/index_template.html --preload-file assets"
+flags="-sEXPORTED_RUNTIME_METHODS=['HEAPF32'] -sUSE_GLFW=3 -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sASSERTIONS --shell-file source/main_web/index_template.html --preload-file assets"
 
 # For debugging: Add `-g` to `emcc` (gives better error callstack in chrome)
 emcc -o $OUT_DIR/index.html $files $flags


### PR DESCRIPTION
Added HEAPF32 to exports in windows and linux wasm build to allow working audio. 

I think this Fixes #13 but I have zero idea if this has other side effects. My project now plays mp3 and ogg just fine.